### PR TITLE
fix crash on set collections page

### DIFF
--- a/scenes/collectionsSceneGroup.lua
+++ b/scenes/collectionsSceneGroup.lua
@@ -13,7 +13,7 @@ PP.collectionsSceneGroup = function()
 	end
 
 	local function itemSetCollectionsProgressBars()
-		PP.Bars(ITEM_SET_COLLECTIONS_BOOK_KEYBOARD.summaryScrollChil, true)
+		PP.Bars(ITEM_SET_COLLECTIONS_BOOK_KEYBOARD.summaryScrollChild, true)
 	end
 
 	local fragments	= {RIGHT_BG_FRAGMENT, TREE_UNDERLAY_FRAGMENT, TITLE_FRAGMENT, COLLECTIONS_TITLE_FRAGMENT, MEDIUM_LEFT_PANEL_BG_FRAGMENT}


### PR DESCRIPTION
fixed typo in `collectionsSceneGroup.lua:16` causing crash

credit [quickc](https://www.esoui.com/forums/member.php?u=71539) for finding