### PR TITLE
AvA scene group reworked

### DIFF
--- a/PerfectPixel/functions.lua
+++ b/PerfectPixel/functions.lua
@@ -695,7 +695,9 @@ end
 -- Function to remove fragments from a scene
 local removeFragmentsFromScene = function(scene, fragments)
 	for _, fragment in ipairs(fragments) do
-	  scene:RemoveFragment(fragment)
+		if scene and scene:HasFragment(fragment) then
+			scene:RemoveFragment(fragment)
+		end
 	end
 end
 

--- a/PerfectPixel/scenes/allianceWarSceneGroup.lua
+++ b/PerfectPixel/scenes/allianceWarSceneGroup.lua
@@ -1,44 +1,51 @@
 local PP = PP ---@class PP
 local removeFragmentsFromScene = PP.removeFragmentsFromScene
 
-PP.allianceWarSceneGroup = function()
-	local scenes = {
-		{ scene = CAMPAIGN_OVERVIEW_SCENE,	gVar = CAMPAIGN_OVERVIEW,	},
-		{ scene = CAMPAIGN_BROWSER_SCENE,	gVar = CAMPAIGN_BROWSER,	},
-	}
-	local fragments	= { FRAME_PLAYER_FRAGMENT, RIGHT_BG_FRAGMENT, TREE_UNDERLAY_FRAGMENT, TITLE_FRAGMENT, ALLIANCE_WAR_TITLE_FRAGMENT, }
+local DEFAULT_ALLIANCE_WAR_SCENES = {
+	{
+		sceneObj = CAMPAIGN_OVERVIEW_SCENE,
+		someGlobalObj = CAMPAIGN_OVERVIEW,
+	},
+	{
+		sceneObj = CAMPAIGN_BROWSER_SCENE,
+		someGlobalObj = CAMPAIGN_BROWSER,
+	},
+}
 
-	for _, sceneInfo in ipairs(scenes) do
-		local scene = sceneInfo.scene
-		local gVar = sceneInfo.gVar
+local FRAGMENTS_TO_REMOVE = {
+	FRAME_PLAYER_FRAGMENT,
+	RIGHT_BG_FRAGMENT,
+	TREE_UNDERLAY_FRAGMENT,
+	TITLE_FRAGMENT,
+	ALLIANCE_WAR_TITLE_FRAGMENT,
+}
 
-		-- Remove fragments from the current scene
-		removeFragmentsFromScene(scene, fragments)
+local function MainStuffMustDoneHere(scene, topLevelControl)
+	removeFragmentsFromScene(scene, FRAGMENTS_TO_REMOVE)
 
-		local tlc	= gVar.control
-		--local list	= gVar.list
+	PP:CreateBackground(topLevelControl, --[[#1]] nil, nil, nil, -10, -10, --[[#2]] nil, nil, nil, 0, 10)
+	PP.Anchor(topLevelControl, --[[#1]] TOPRIGHT, GuiRoot, TOPRIGHT, 0, 120, --[[#2]] true, BOTTOMRIGHT, GuiRoot, BOTTOMRIGHT, 0, -70)
+end
+PP.allianceWarSceneGroupMainStuff = MainStuffMustDoneHere
 
-		PP:CreateBackground(tlc, --[[#1]] nil, nil, nil, -10, -10, --[[#2]] nil, nil, nil, 0, 10)
-		PP.Anchor(tlc, --[[#1]] TOPRIGHT, GuiRoot, TOPRIGHT, 0, 120, --[[#2]] true, BOTTOMRIGHT, GuiRoot, BOTTOMRIGHT, 0, -70)
-		-- ZO_ScrollList_Commit(list)
-	end
-
---ZO_CampaignOverview------------------------------------------------------------------------------------------------------------------------------
+local function AdditionalStuff()
 	PP.Anchor(ZO_CampaignOverviewCategories, --[[#1]] TOPLEFT, ZO_CampaignOverview, TOPLEFT, 0, 68)
 	PP.Anchor(ZO_CampaignSelector, --[[#1]] BOTTOMRIGHT, ZO_CampaignOverviewTopDivider, TOPRIGHT, -165, 25)
 
---ZO_CampaignBrowser
-	local campaignBrowserScene = scenes[2].scene -- CAMPAIGN_BROWSER_SCENE
-	--local campaignBrowserObj = scenes[2].gVar -- CAMPAIGN_BROWSER
-
 	local campaignBrowserXPBarChanged = false
-	campaignBrowserScene:RegisterCallback("StateChange", function(oldState, newState)
+	CAMPAIGN_BROWSER_SCENE:RegisterCallback("StateChange", function(oldState, newState)
 		if newState == SCENE_SHOWN and not campaignBrowserXPBarChanged then
 			PP.Bar(GetControl(ZO_CampaignAvARank, "XPBar"), 14, 15, nil, nil, true)
 			campaignBrowserXPBarChanged = true
         --elseif newState == SCENE_HIDDEN then
         end
 	end)
+end
 
----------------------------------------------------------------------------------------------------
+PP.allianceWarSceneGroup = function()
+	for _, scene in ipairs(DEFAULT_ALLIANCE_WAR_SCENES) do
+		MainStuffMustDoneHere(scene.sceneObj, scene.someGlobalObj.control)
+	end
+
+	AdditionalStuff()
 end

--- a/PerfectPixel/scenes/allianceWarSceneGroup.lua
+++ b/PerfectPixel/scenes/allianceWarSceneGroup.lua
@@ -2,14 +2,8 @@ local PP = PP ---@class PP
 local removeFragmentsFromScene = PP.removeFragmentsFromScene
 
 local DEFAULT_ALLIANCE_WAR_SCENES = {
-	{
-		sceneObj = CAMPAIGN_OVERVIEW_SCENE,
-		someGlobalObj = CAMPAIGN_OVERVIEW,
-	},
-	{
-		sceneObj = CAMPAIGN_BROWSER_SCENE,
-		someGlobalObj = CAMPAIGN_BROWSER,
-	},
+	{ scene = CAMPAIGN_OVERVIEW_SCENE, gVar = CAMPAIGN_OVERVIEW, },
+	{ scene = CAMPAIGN_BROWSER_SCENE, gVar = CAMPAIGN_BROWSER, },
 }
 
 local FRAGMENTS_TO_REMOVE = {
@@ -20,15 +14,15 @@ local FRAGMENTS_TO_REMOVE = {
 	ALLIANCE_WAR_TITLE_FRAGMENT,
 }
 
-local function MainStuffMustDoneHere(scene, topLevelControl)
+local function EditScene(scene, topLevelControl)
 	removeFragmentsFromScene(scene, FRAGMENTS_TO_REMOVE)
 
 	PP:CreateBackground(topLevelControl, --[[#1]] nil, nil, nil, -10, -10, --[[#2]] nil, nil, nil, 0, 10)
 	PP.Anchor(topLevelControl, --[[#1]] TOPRIGHT, GuiRoot, TOPRIGHT, 0, 120, --[[#2]] true, BOTTOMRIGHT, GuiRoot, BOTTOMRIGHT, 0, -70)
 end
-PP.allianceWarSceneGroupMainStuff = MainStuffMustDoneHere
+PP.allianceWarSceneGroupEditScene = EditScene
 
-local function AdditionalStuff()
+local function EditElements()
 	PP.Anchor(ZO_CampaignOverviewCategories, --[[#1]] TOPLEFT, ZO_CampaignOverview, TOPLEFT, 0, 68)
 	PP.Anchor(ZO_CampaignSelector, --[[#1]] BOTTOMRIGHT, ZO_CampaignOverviewTopDivider, TOPRIGHT, -165, 25)
 
@@ -44,8 +38,8 @@ end
 
 PP.allianceWarSceneGroup = function()
 	for _, scene in ipairs(DEFAULT_ALLIANCE_WAR_SCENES) do
-		MainStuffMustDoneHere(scene.sceneObj, scene.someGlobalObj.control)
+		EditScene(scene.scene, scene.gVar.control)
 	end
 
-	AdditionalStuff()
+	EditElements()
 end

--- a/PerfectPixel/scenes/journalSceneGroup.lua
+++ b/PerfectPixel/scenes/journalSceneGroup.lua
@@ -18,7 +18,7 @@ local FRAGMENTS_TO_REMOVE = {
 	JOURNAL_TITLE_FRAGMENT,
 }
 
-local function MainStuff(scene, topLevelControl)
+local function EditScene(scene, topLevelControl)
 	-- local filter 		= 		gVar.filter or gVar.categoryFilter
 	-- local progressBar   = 		gVar.categoryProgress
 	-- local sceneShowCallback = 	scenes[i].sceneShowCallback
@@ -55,7 +55,7 @@ local function MainStuff(scene, topLevelControl)
 	end
 	]=]
 end
-PP.journalSceneGroupMainStuff = MainStuff
+PP.journalSceneGroupEditScene = EditScene
 
 local SV
 
@@ -81,7 +81,7 @@ local function SetupSavedVariables()
 			})
 end
 
-local function PP_ZO_QuestJournal()
+local function Edit_ZO_QuestJournal()
 	SetupSavedVariables()
 
 	--questJournal--ZO_QuestJournal--------------------------------------------------------------------
@@ -179,7 +179,7 @@ local function PP_ZO_QuestJournal()
 	end
 end
 
-local function PP_ZO_Cadwell()
+local function Edit_ZO_Cadwell()
 	--Antiquities--ZO_Cadwell--------------------------------------------------------------------
 	--cadwellsAlmanac--ZO_Cadwell--------------------------------------------------------------------
 	--Antiquities--------------------------------------------------------------------
@@ -192,7 +192,7 @@ local function PP_ZO_Cadwell()
 	end, nil) -- ZO_AntiquityJournal_Keyboard:OnDeferredInitialize
 end
 
-local function PP_ZO_Achievements()
+local function Edit_ZO_Achievements()
 	--achievements--ZO_Achievements--------------------------------------------------------------------
 
 	--PTS API101043 2024-08-07
@@ -220,24 +220,24 @@ local function PP_ZO_Achievements()
 	-- end
 end
 
-local function PP_ZO_LoreLibrary()
+local function Edit_ZO_LoreLibrary()
 	--loreLibrary--ZO_LoreLibrary----------------------------------------------------------------------
 	local loreLibraryObj = LORE_LIBRARY  -- scenes[4].gVar --LORE_LIBRARY
 	PP.ScrollBar(loreLibraryObj.navigationTree.scrollControl, --[[sb_c]] 180, 180, 180, 0.7, --[[bd_c]] 20, 20, 20, 0.7, false) --ZO_LoreLibraryNavigationContainer
 	PP.ScrollBar(loreLibraryObj.list.list, --[[sb_c]] 180, 180, 180, 0.7, --[[bd_c]] 20, 20, 20, 0.7, false)
 end
 
-local function PP_ZO_Leaderboard()
+local function Edit_ZO_Leaderboard()
 	--leaderboards--ZO_Leaderboards--------------------------------------------------------------------
 	PP.ScrollBar(ZO_LeaderboardsList, --[[sb_c]] 180, 180, 180, 0.7, --[[bd_c]] 20, 20, 20, 0.7, false)
 end
 
-local function AdditionalStuff()
-	PP_ZO_QuestJournal()
-	PP_ZO_Cadwell()
-	PP_ZO_Achievements()
-	PP_ZO_LoreLibrary()
-	PP_ZO_Leaderboard()
+local function EditElements()
+	Edit_ZO_QuestJournal()
+	Edit_ZO_Cadwell()
+	Edit_ZO_Achievements()
+	Edit_ZO_LoreLibrary()
+	Edit_ZO_Leaderboard()
 end
 
 PP.journalSceneGroup = function()
@@ -246,8 +246,8 @@ PP.journalSceneGroup = function()
 	-- end
 
 	for _, scene in ipairs(DEFAULT_JOURNAL_SCENES) do
-		MainStuff(scene.scene, scene.gVar.control)
+		EditScene(scene.scene, scene.gVar.control)
 	end
 
-	AdditionalStuff()
+	EditElements()
 end

--- a/PerfectPixel/scenes/journalSceneGroup.lua
+++ b/PerfectPixel/scenes/journalSceneGroup.lua
@@ -1,78 +1,88 @@
 local PP = PP ---@class PP
 local removeFragmentsFromScene = PP.removeFragmentsFromScene
 
-PP.journalSceneGroup = function()
-	--===============================================================================================--
+local DEFAULT_JOURNAL_SCENES = {
+	{ scene = QUEST_JOURNAL_SCENE,							gVar = QUEST_JOURNAL_KEYBOARD,		},
+	{ scene = ANTIQUITY_JOURNAL_KEYBOARD_SCENE,				gVar = ANTIQUITY_JOURNAL_KEYBOARD,	},
+	{ scene = SCENE_MANAGER:GetScene('cadwellsAlmanac'),	gVar = CADWELLS_ALMANAC,			},
+	{ scene = LORE_LIBRARY_SCENE,							gVar = LORE_LIBRARY,				},
+	{ scene = SCENE_MANAGER:GetScene('achievements'),		gVar = ACHIEVEMENTS,				--[[sceneShowCallback = achievementsProgressBars]]},
+	{ scene = LEADERBOARDS_SCENE,							gVar = LEADERBOARDS,				},
+}
+
+local FRAGMENTS_TO_REMOVE = {
+	FRAME_PLAYER_FRAGMENT,
+	RIGHT_BG_FRAGMENT,
+	TREE_UNDERLAY_FRAGMENT,
+	TITLE_FRAGMENT,
+	JOURNAL_TITLE_FRAGMENT,
+}
+
+local function MainStuff(scene, topLevelControl)
+	-- local filter 		= 		gVar.filter or gVar.categoryFilter
+	-- local progressBar   = 		gVar.categoryProgress
+	-- local sceneShowCallback = 	scenes[i].sceneShowCallback
+
+	removeFragmentsFromScene(scene, FRAGMENTS_TO_REMOVE)
+
+	local tlc	= topLevelControl
+	-- local list	= gVar.list
+
+	PP:CreateBackground(tlc, --[[#1]] nil, nil, nil, -10, -15, --[[#2]] nil, nil, nil, 0, 10)
+	PP.Anchor(tlc, --[[#1]] TOPRIGHT, GuiRoot, TOPRIGHT, 0, 120, --[[#2]] true, BOTTOMRIGHT, GuiRoot, BOTTOMRIGHT, 0, -70)
+
+	--[=[
+	PP.Anchor(list, --[[#1]] nil, nil, nil, 0, 3, --[[#2]] true, nil, nil, nil, 0, 0)
+	PP.ScrollBar(list,	--[[sb_c]] 180, 180, 180, .7, --[[bd_c]] 20, 20, 20, .7, false)
+	ZO_ScrollList_Commit(list)
+	if progressBar then
+	PP.Bar(progressBar, --[[h]] 14, --[[f]] 15, 255, nil)
+	end
+	if filter then
+	Change the drawTier of the filter dropdown boxes so they get overlayed by the background backdrop
+	filter:SetDrawTier(DT_MEDIUM)
+	filter:SetDrawLayer(DL_TEXT)
+	filter:SetDrawLevel(1)
+	end
+
+	if sceneShowCallback ~= nil then
+	scene:RegisterCallback("StateChange", function(oldState, newState)
+	if newState == SCENE_SHOWN and not scenesShown[scene] then
+	sceneShowCallback()
+	scenesShown[scene] = true
+	end
+	end)
+	end
+	]=]
+end
+PP.journalSceneGroupMainStuff = MainStuff
+
+local SV
+
+local function SetupSavedVariables()
 	local SV_VER		= 0.4
 	local DEF = {
 		largeQuestList	= true,
 	}
-	local SV = ZO_SavedVars:NewAccountWide(PP.ADDON_NAME, SV_VER, "JournalScene", DEF, GetWorldName())
+	SV = ZO_SavedVars:NewAccountWide(PP.ADDON_NAME, SV_VER, "JournalScene", DEF, GetWorldName())
 	---------------------------------------------
 	table.insert(PP.optionsData,
 			{	type				= "submenu",
-				 name				= GetString(PP_LAM_SCENE_JOURNAL),
-				 controls = {
-					 {	type				= "checkbox",
-						  name				= GetString(PP_LAM_SCENE_JOURNAL_QUEST_LARGE_LIST),
-						  getFunc				= function() return SV.largeQuestList end,
-						  setFunc				= function(value) SV.largeQuestList = value end,
-						  default				= DEF.largeQuestList,
-						  requiresReload		= true,
-					 },
-				 },
+					name				= GetString(PP_LAM_SCENE_JOURNAL),
+					controls = {
+						{	type				= "checkbox",
+							name				= GetString(PP_LAM_SCENE_JOURNAL_QUEST_LARGE_LIST),
+							getFunc				= function() return SV.largeQuestList end,
+							setFunc				= function(value) SV.largeQuestList = value end,
+							default				= DEF.largeQuestList,
+							requiresReload		= true,
+						},
+					},
 			})
-	--===============================================================================================--
-	local function achievementsProgressBars()
-		PP.Bars(ACHIEVEMENTS.summaryProgressBarsScrollChild, false, nil, nil, nil, nil, true)
-	end
-	local scenes = {
-		{ scene = QUEST_JOURNAL_SCENE,							gVar = QUEST_JOURNAL_KEYBOARD,		},
-		{ scene = ANTIQUITY_JOURNAL_KEYBOARD_SCENE,				gVar = ANTIQUITY_JOURNAL_KEYBOARD,	},
-		{ scene = SCENE_MANAGER:GetScene('cadwellsAlmanac'),	gVar = CADWELLS_ALMANAC,			},
-		{ scene = LORE_LIBRARY_SCENE,							gVar = LORE_LIBRARY,				},
-		{ scene = SCENE_MANAGER:GetScene('achievements'),		gVar = ACHIEVEMENTS,				--[[sceneShowCallback = achievementsProgressBars]]},
-		{ scene = LEADERBOARDS_SCENE,							gVar = LEADERBOARDS,				},
-	}
-	local fragments	= { FRAME_PLAYER_FRAGMENT, RIGHT_BG_FRAGMENT, TREE_UNDERLAY_FRAGMENT, TITLE_FRAGMENT, JOURNAL_TITLE_FRAGMENT, }
-	-- local scenesShown = {}
-	for _, sceneInfo in ipairs(scenes) do
-		local scene = sceneInfo.scene
-		local gVar = sceneInfo.gVar
-		-- local filter 		= 		gVar.filter or gVar.categoryFilter
-		-- local progressBar   = 		gVar.categoryProgress
-		-- local sceneShowCallback = 	scenes[i].sceneShowCallback
+end
 
-		removeFragmentsFromScene(scene, fragments)
-
-		local tlc	= gVar.control
-		-- local list	= gVar.list
-
-		PP:CreateBackground(tlc, --[[#1]] nil, nil, nil, -10, -10, --[[#2]] nil, nil, nil, 0, 10)
-		PP.Anchor(tlc, --[[#1]] TOPRIGHT, GuiRoot, TOPRIGHT, 0, 120, --[[#2]] true, BOTTOMRIGHT, GuiRoot, BOTTOMRIGHT, 0, -70)
-
-		-- PP.Anchor(list, --[[#1]] nil, nil, nil, 0, 3, --[[#2]] true, nil, nil, nil, 0, 0)
-		-- PP.ScrollBar(list,	--[[sb_c]] 180, 180, 180, .7, --[[bd_c]] 20, 20, 20, .7, false)
-		-- ZO_ScrollList_Commit(list)
-		-- if progressBar then
-		-- PP.Bar(progressBar, --[[h]] 14, --[[f]] 15, 255, nil)
-		-- end
-		-- if filter then
-		-- Change the drawTier of the filter dropdown boxes so they get overlayed by the background backdrop
-		-- filter:SetDrawTier(DT_MEDIUM)
-		-- filter:SetDrawLayer(DL_TEXT)
-		-- filter:SetDrawLevel(1)
-		-- end
-
-		-- if sceneShowCallback ~= nil then
-		-- scene:RegisterCallback("StateChange", function(oldState, newState)
-		-- if newState == SCENE_SHOWN and not scenesShown[scene] then
-		-- sceneShowCallback()
-		-- scenesShown[scene] = true
-		-- end
-		-- end)
-		-- end
-	end
+local function PP_ZO_QuestJournal()
+	SetupSavedVariables()
 
 	--questJournal--ZO_QuestJournal--------------------------------------------------------------------
 	PP.ScrollBar(ZO_QuestJournalNavigationContainer, --[[sb_c]] 180, 180, 180, 0.7, --[[bd_c]] 20, 20, 20, 0.7, false)
@@ -82,7 +92,7 @@ PP.journalSceneGroup = function()
 	ZO_Scroll_SetMaxFadeDistance(ZO_QuestJournalNavigationContainer, 10)
 
 	if SV.largeQuestList then
-		local questJournalKeyboardObj = scenes[1].gVar --QUEST_JOURNAL_KEYBOARD
+		local questJournalKeyboardObj = QUEST_JOURNAL_KEYBOARD  -- scenes[1].gVar -- QUEST_JOURNAL_KEYBOARD
 		local tree = questJournalKeyboardObj.navigationTree
 		tree.defaultIndent = 50		--[[def (40)]]
 		tree.defaultSpacing = 0		--[[def (-10)]]
@@ -167,28 +177,26 @@ PP.journalSceneGroup = function()
 
 		questJournalKeyboardObj.listDirty = true
 	end
+end
 
+local function PP_ZO_Cadwell()
 	--Antiquities--ZO_Cadwell--------------------------------------------------------------------
 	--cadwellsAlmanac--ZO_Cadwell--------------------------------------------------------------------
 	--Antiquities--------------------------------------------------------------------
 	--PTS API101043 2024-08-07
-	local antiquityJournalKeyboardObj = scenes[2].gVar --ANTIQUITY_JOURNAL_KEYBOARD
+	local antiquityJournalKeyboardObj = ANTIQUITY_JOURNAL_KEYBOARD  -- scenes[2].gVar --ANTIQUITY_JOURNAL_KEYBOARD
 	PP.onDeferredInitCheck(antiquityJournalKeyboardObj, function()
 		PP.ScrollBar(antiquityJournalKeyboardObj.contentList, --[[sb_c]] 180, 180, 180, 0.7, --[[bd_c]] 20, 20, 20, 0.7, false) --ZO_AntiquityJournal_Keyboard_TopLevelContentsContentList
 		--API101045 2025-01-17 Add missing progressbar UI styling
 		PP.Bar(antiquityJournalKeyboardObj.categoryProgress, 14, 15)
 	end, nil) -- ZO_AntiquityJournal_Keyboard:OnDeferredInitialize
+end
 
---loreLibrary--ZO_LoreLibrary----------------------------------------------------------------------
-	local loreLibraryObj = scenes[4].gVar --LORE_LIBRARY
-	PP.ScrollBar(loreLibraryObj.navigationTree.scrollControl, --[[sb_c]] 180, 180, 180, 0.7, --[[bd_c]] 20, 20, 20, 0.7, false) --ZO_LoreLibraryNavigationContainer
-	PP.ScrollBar(loreLibraryObj.list.list, --[[sb_c]] 180, 180, 180, 0.7, --[[bd_c]] 20, 20, 20, 0.7, false)
-
-
---achievements--ZO_Achievements--------------------------------------------------------------------
+local function PP_ZO_Achievements()
+	--achievements--ZO_Achievements--------------------------------------------------------------------
 
 	--PTS API101043 2024-08-07
-	local achievementsObj = scenes[5].gVar --ACHIEVEMENTS
+	local achievementsObj = ACHIEVEMENTS  -- scenes[5].gVar --ACHIEVEMENTS
 	PP.onDeferredInitCheck(achievementsObj, function()
 		PP.ScrollBar(ZO_AchievementsContentsCategories, --[[sb_c]] 180, 180, 180, 0.7, --[[bd_c]] 20, 20, 20, 0.7, false)
 		PP.ScrollBar(achievementsObj.contentList, --[[sb_c]] 180, 180, 180, 0.7, --[[bd_c]] 20, 20, 20, 0.7, false)
@@ -210,8 +218,36 @@ PP.journalSceneGroup = function()
 			-- recentAchievementIcon:SetDrawLevel(1)
 		-- end
 	-- end
+end
 
+local function PP_ZO_LoreLibrary()
+	--loreLibrary--ZO_LoreLibrary----------------------------------------------------------------------
+	local loreLibraryObj = LORE_LIBRARY  -- scenes[4].gVar --LORE_LIBRARY
+	PP.ScrollBar(loreLibraryObj.navigationTree.scrollControl, --[[sb_c]] 180, 180, 180, 0.7, --[[bd_c]] 20, 20, 20, 0.7, false) --ZO_LoreLibraryNavigationContainer
+	PP.ScrollBar(loreLibraryObj.list.list, --[[sb_c]] 180, 180, 180, 0.7, --[[bd_c]] 20, 20, 20, 0.7, false)
+end
 
---leaderboards--ZO_Leaderboards--------------------------------------------------------------------
+local function PP_ZO_Leaderboard()
+	--leaderboards--ZO_Leaderboards--------------------------------------------------------------------
 	PP.ScrollBar(ZO_LeaderboardsList, --[[sb_c]] 180, 180, 180, 0.7, --[[bd_c]] 20, 20, 20, 0.7, false)
+end
+
+local function AdditionalStuff()
+	PP_ZO_QuestJournal()
+	PP_ZO_Cadwell()
+	PP_ZO_Achievements()
+	PP_ZO_LoreLibrary()
+	PP_ZO_Leaderboard()
+end
+
+PP.journalSceneGroup = function()
+	-- local function achievementsProgressBars()
+	-- 	PP.Bars(ACHIEVEMENTS.summaryProgressBarsScrollChild, false, nil, nil, nil, nil, true)
+	-- end
+
+	for _, scene in ipairs(DEFAULT_JOURNAL_SCENES) do
+		MainStuff(scene.scene, scene.gVar.control)
+	end
+
+	AdditionalStuff()
 end


### PR DESCRIPTION
Hello! I would like to discuss compatibility with other addons in general and improvements to allianceWarSceneGroup in particular. I am working on UI addons and would like to make them work with PP seamlessly, so if any changes be done to PP, it would also affect my addon too, but I would also want to have more precise control (for example, be able to turn PP compatibility on and off). So all this leads to one conclusion - I should add compatibility to PP in my addon myself and not rely on compatibilty.lua inside PP.

It is pretty hard to do what I want now, let me explain on allianceWarSceneGroup example. I have added new (third tab) to this group, but PP knows nothing about it and my scene stays unchanged. I want to change it in the same manner as PP changed first two tabs (overview and browser), but how can I do it? The only way is to copy part of the code from PP and paste to my addon. Then I should check, if PP is enabled and invoke or not the code from PP. But if PP changes in the future, my code will possibly break and I will need to copy updated functions. 

After some changes the same can be done like this (snippet from my wip addon):
```lua
    local function MakeItPerfect()
        PP.allianceWarSceneGroupMainStuff(MY_NEW_SCENE, topLevelControl)
    end

    if PP then
        ZO_PostHook(PP, 'allianceWarSceneGroup', MakeItPerfect)
    end
```
So I only need to hook a function which changes two first tabs (but MakeItPerfect can invoked in any different way) and call the same function from PP, which will change MY_NEW_SCENE in the same manner as Overview and Browser were changed. As a result, I will receive good-looking tab without struggling from copy-pasting. And this is true for other menus - many authors could make their addons compatible if PP had more standardized ways of doing stuff.

I made changes to PerfectPixel\scenes\allianceWarSceneGroup.lua, please check it out. Please note I made variables easy to understand what they should be and them should be changed afterwards.