### PR TITLE
Add compatibility for ImprovedGoldenPursuits

### DIFF
--- a/PerfectPixel/PerfectPixel.txt
+++ b/PerfectPixel/PerfectPixel.txt
@@ -7,7 +7,7 @@
 ## SavedVariables: PerfectPixel
 
 ## OptionalDependsOn: LibAddonMenu-2.0>=40 LibCustomMenu>=730 LibMapPins-1.0>=10043 LibScrollableMenu>=020306 LibVotansAddonList>=10903 LibMediaProvider>=34
-## OptionalDependsOn: AdvancedFilters>=1649 SpentSkillPoints FCOLockPicker>=002080 PreUpdate101046UI BeamMeUp
+## OptionalDependsOn: AdvancedFilters>=1649 SpentSkillPoints FCOLockPicker>=002080 PreUpdate101046UI BeamMeUp ImprovedGoldenPursuits
 
 Init.lua
 fonts.xml

--- a/PerfectPixel/compatibility.lua
+++ b/PerfectPixel/compatibility.lua
@@ -1369,6 +1369,24 @@ d("[PP]GUILD_HISTORY_KEYBOARD_SCENE:SHown")
             end
         end
 
+        -- ==ImprovedGoldenPursuits==
+        if IGP then
+            SecurePostHook(PROMOTIONAL_EVENTS_KEYBOARD, "OnDeferredInitialize", function()
+                -- Move combobox (and attached checkboxes) a bit lower
+                IGP.controls.sortingDropdown.m_container:ClearAnchors()
+                IGP.controls.sortingDropdown.m_container:SetAnchor(BOTTOMRIGHT, ZO_PromotionalEvents_KeyboardTL, TOPRIGHT, 2, 12)
+                -- Reanchor content to show below combobox
+                local shown = false
+                PROMOTIONAL_EVENTS_PREVIEW_OPTIONS_FRAGMENT:RegisterCallback("StateChange", function(oldState, newState)
+                    if newState == SCENE_FRAGMENT_SHOWN and not shown then
+                        ZO_PromotionalEvents_KeyboardTLContentsCampaignPanelProgress:ClearAnchors() --Progress bar
+                        ZO_PromotionalEvents_KeyboardTLContentsCampaignPanelProgress:SetAnchor(TOPLEFT,	ZO_PromotionalEvents_KeyboardTLContentsCampaignPanelName, BOTTOMLEFT, 9, 120)
+                        shown = true
+                    end
+                end)
+            end)
+        end
+
         -- ===============================================================================================--
         -- ==Misc ZO things==--
         -- ===============================================================================================--


### PR DESCRIPTION
Adds compatibilty for my Improved Golden Pursuits addon.

Latest update of PerfectPixel removed the Golden Pursuits banner image. Since my addon anchored it's UI elements to be above the image, the new placement of the remaining time and name overlaps with those.

![Visuals after applied patch](https://i.imgur.com/TEULnxP.png)

Anchor offsets may be changed to your liking, I found the ones used to not look bad :)