### PR TITLE
Update draw properties for TLW_BG window

### DIFF
--- a/PerfectPixel/functions.lua
+++ b/PerfectPixel/functions.lua
@@ -102,9 +102,9 @@ function PP.PostHooksSetupCallback(list, mode, typeId, onCreateFn, onUpdateFn)
 end
 
 local TLW_BG = CreateTopLevelWindow(nil)
-TLW_BG:SetDrawLayer(0)
-TLW_BG:SetDrawLevel(0)
-TLW_BG:SetDrawTier(0)
+TLW_BG:SetDrawLayer(DL_BACKGROUND)
+TLW_BG:SetDrawLevel(1)
+TLW_BG:SetDrawTier(DT_LOW)
 
 PP.TLW_BG = TLW_BG
 


### PR DESCRIPTION
This allows PP elements to draw on top of world markers, the markers created in the image is from Survey Reset Markers that uses LibCombatAlerts world drawing to generate 3D markers. It would be easier to just change the level we render on instead of trying to get others to change.

Before:
<img width="954" height="289" alt="before_change" src="https://github.com/user-attachments/assets/291f3897-daf4-4294-a427-a32a95bd1657" />

After:
<img width="599" height="373" alt="after_change" src="https://github.com/user-attachments/assets/2444f3bf-416c-46cc-8109-7b34c0843990" />
