### PR TITLE
Add gildbarStoreSceneKeyboard and hide munge overlay in scenes

### DIFF
--- a/PerfectPixel/PerfectPixel.lua
+++ b/PerfectPixel/PerfectPixel.lua
@@ -48,7 +48,7 @@ function PP.Core()
 	PP.Anchor(ZO_MainMenuSceneGroupBar, --[[#1]] TOPRIGHT, GuiRoot, TOPRIGHT, -30, 64)
 
 --FIX market scene
-	local tabMarketScenes = {"market", "endeavorSealStoreSceneKeyboard", "esoPlusOffersSceneKeyboard", "dailyLoginRewards", "giftInventoryKeyboard"}
+	local tabMarketScenes = {"market", "gildbarStoreSceneKeyboard", "endeavorSealStoreSceneKeyboard", "esoPlusOffersSceneKeyboard", "dailyLoginRewards", "giftInventoryKeyboard"}
 	for _, scene in pairs(tabMarketScenes) do
 		SCENE_MANAGER:GetScene(scene):RegisterCallback("StateChange", function(oldState, newState)
 			if newState == SCENE_SHOWING then

--- a/PerfectPixel/scenes/tamrielTomesScene.lua
+++ b/PerfectPixel/scenes/tamrielTomesScene.lua
@@ -20,6 +20,10 @@ PP.tamrielTomesScene = function ()
         -- ZO_TimedActivities_KeyboardTLBG is an existing CT_BACKDROP (ZO_DefaultBackdrop + AnchorFill)
         -- Passing it directly reskins it with PP style rather than creating a second backdrop
         PP:CreateBackground(ZO_TimedActivities_KeyboardTLBG)
+        local mungeOverlay = ZO_TimedActivities_KeyboardTLBGMungeOverlay
+        if mungeOverlay then
+            mungeOverlay:SetHidden(true)
+        end
 
         PP.Font(ZO_TimedActivities_KeyboardTLContentHeaderTitle, --[[Font]] PP.f.u67, 24, "outline")
         PP.Font(ZO_TimedActivities_KeyboardTLContentHeaderResetTime, --[[Font]] PP.f.u67, 18, "outline")


### PR DESCRIPTION
The `gildbarStoreSceneKeyboard` is missing from our market fix.
This will resolve the display issue. 

<img width="970" height="237" alt="image" src="https://github.com/user-attachments/assets/0b7e38cf-f161-4056-8b67-f37f90437aee" />
